### PR TITLE
Update _metrics.py to include two new metrics

### DIFF
--- a/src/tdamapper/utils/_metrics.py
+++ b/src/tdamapper/utils/_metrics.py
@@ -29,3 +29,15 @@ def cosine(x, y):
     yy = np.linalg.norm(y)
     similarity = xy / (xx * yy)
     return np.sqrt(2.0 * (1.0 - similarity))
+
+@njit(fastmath=True) # pragma: no cover
+def hamming(x,y):
+    return x.size - np.count_nonzero(x-y)
+    
+@njit(fastmath=True): # pragma: no cover
+    def nine_wildcard_hamming(x,y):
+        a = x-y
+        return a.size - np.count_nonzero(np.logical_or(a ==0, np.logical_or(a >= 5, a <= -5) ))
+        
+        
+        


### PR DESCRIPTION
The hamming distance between two strings is the number of entries on which they differ. I suggest introducing the hamming metric on numpy arrays (of numbers) and a function, bounded_hamming, which allows for the use of 9 as a wildcard on datasets containing entries at most 4 (the resulting psuedometric has convenient applications to genomics)